### PR TITLE
fix: 첫 진입시 오늘날짜 선택안되는 이슈 수정

### DIFF
--- a/src/app/luckytree/_components/steps/LuckyDateStep.tsx
+++ b/src/app/luckytree/_components/steps/LuckyDateStep.tsx
@@ -21,7 +21,7 @@ export default function LuckyDateStep({ useluckyTree, onClickSubmit }: LuckyDate
 
   const { toast } = useToast();
 
-  const [date, setDate] = useState<Date | undefined>(new Date());
+  const [date, setDate] = useState<Date | undefined>();
 
   const onSelectDate = (date: Date | undefined) => {
     const selectedDate = dayjs(date);
@@ -54,6 +54,7 @@ export default function LuckyDateStep({ useluckyTree, onClickSubmit }: LuckyDate
             mode="single"
             selected={date}
             onSelect={onSelectDate}
+            fromDate={new Date()}
             className="max-w-[280px] rounded-md border border-[#40407C] bg-[#0B082B] px-[50px] text-white"
           />
         </VStack>


### PR DESCRIPTION
#42 

### 작업사항
* 첫 진입시 오늘 날짜 선택 안되는 이슈 수정
* Calendar에 이전 날짜 선택 disabled 처리 옵션 추가