### PR TITLE
fix: 폰번호 인증코드 재요청누르면 아래에 인증코드가 유효하지 않다고 표시되는 이슈 해결

### DIFF
--- a/src/app/(login)/signin/_components/steps/InfoPhoneNumberStep.tsx
+++ b/src/app/(login)/signin/_components/steps/InfoPhoneNumberStep.tsx
@@ -55,7 +55,7 @@ export default function InfoPhoneNumberStep({
       resetCountdown();
       startCountdown();
       updateFields({ certCode: null });
-      setIsSMSSuccess(false);
+      setIsSMSSuccess(null);
 
       if (infoData.phoneNumber) {
         postRequestPhoneNumber({ phoneNumber: removeHyphens(infoData.phoneNumber) })


### PR DESCRIPTION
#44 